### PR TITLE
SFR-80 Add publication date sort to instances

### DIFF
--- a/docs/elastic_model.md
+++ b/docs/elastic_model.md
@@ -38,6 +38,7 @@ Not included in the model documentation below are the `date_created` and `date_m
 - instances (Nested)
 
 ### Instance
+
 - title (Text)
   - keyword (Keyword)
 - sub_title (Text)
@@ -47,6 +48,9 @@ Not included in the model documentation below are the `date_created` and `date_m
 - pub_place (Text)
   - keyword (Keyword)
 - pub_date (DateRange)
+- pub_date_display (Text)
+- pub_date_sort (Date)
+- pub_date_sort_desc (Date)
 - copyright_date (DateRange)
 - edition (Text)
   - keyword (Keyword)

--- a/lib/esManager.py
+++ b/lib/esManager.py
@@ -273,6 +273,12 @@ class ESDoc():
         for dateType, date in ESDoc._loadDates(instance, ['pub_date']).items():
             ESDoc._insertDate(esInstance, date, dateType)
         
+        if esInstance.pub_date:
+            if esInstance.pub_date.gte:
+                esInstance.pub_date_sort = esInstance.pub_date.gte
+            if esInstance.pub_date.lte:
+                esInstance.pub_date_sort_desc = esInstance.pub_date.lte
+
         #esInstance.identifiers = [
         #    ESDoc.addIdentifier(identifier)
         #    for identifier in instance.identifiers

--- a/model/elasticDocs.py
+++ b/model/elasticDocs.py
@@ -163,6 +163,8 @@ class Instance(BaseInner):
     pub_place = Text(fields={'keyword': Keyword()})
     pub_date = DateRange(format='date_optional_time')
     pub_date_display = Keyword(index=False)
+    pub_date_sort = Date()
+    pub_date_sort_desc = Date()
     edition = Text(fields={'keyword': Keyword()})
     edition_statement = Text(fields={'keyword': Keyword()})
     table_of_contents = Text()

--- a/tests/test_esManager.py
+++ b/tests/test_esManager.py
@@ -3,6 +3,7 @@ import os
 from unittest.mock import patch, MagicMock, call
 from elasticsearch.exceptions import ConnectionError, TransportError, ConflictError
 from elasticsearch.helpers import BulkIndexError
+from elasticsearch_dsl import DateRange
 
 from helpers.errorHelpers import ESError
 
@@ -161,6 +162,24 @@ class TestESManager(unittest.TestCase):
         langRec = ESDoc.addLanguage(testLang)
         self.assertEqual(langRec.language, 'test')
         self.assertEqual(langRec.iso_3, 'tes')
+    
+    def test_insert_instance_w_pub_date(self):
+        testInstance = MagicMock()
+        testDate = MagicMock()
+        testDate.lower = '2019-01-01'
+        testDate.upper = '2019-12-31'
+        dateObj = MagicMock()
+        dateObj.date_type = 'pub_date'
+        dateObj.display_date = '2019'
+        dateObj.date_range = testDate
+        testInstance.title = 'Test Title'
+        testInstance.dates = [dateObj]
+        newInstance = ESDoc.addInstance(testInstance)
+
+        self.assertEqual(newInstance.title, 'Test Title')
+        self.assertEqual(newInstance.pub_date_sort, '2019-01-01')
+        self.assertEqual(newInstance.pub_date_sort_desc, '2019-12-31')
+
 
 
 class TestDict(dict):


### PR DESCRIPTION
ElasticSearch does not permit sorting on `Range` fields, preventing the `pub_date` field from being used to sort search results from the API. This isresolved by the addition here of two new fields: `pub_date_sort` and `pub_date_sort_desc` which enable both old-new and new-old sorting options