### PR TITLE
SFR-582 Add Unique link IDs

### DIFF
--- a/lib/esManager.py
+++ b/lib/esManager.py
@@ -195,6 +195,7 @@ class ESDoc():
             field: getattr(link, field, None) for field in Link.getFields()
         }
         newLink = Link(**linkData)
+        newLink.unique_id = link.id
 
         linkFlags = getattr(link, 'flags', {})
         if isinstance(linkFlags, str): linkFlags = json.loads(linkFlags)
@@ -305,7 +306,7 @@ class ESDoc():
 
         esInstance.items = [
             ESDoc.addItem(item) 
-            for item in instance.items
+            for item in instance.items if len(item.links) > 0
         ]
 
         esInstance.rights = [

--- a/model/elasticDocs.py
+++ b/model/elasticDocs.py
@@ -82,6 +82,7 @@ class Subject(BaseInner):
 
 
 class Link(BaseInner):
+    unique_id = Integer(index=False)
     url = Keyword(index=False)
     media_type = Keyword()
     label = Text()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 babelfish
-elasticsearch
-elasticsearch_dsl
+elasticsearch==6.3.1
+elasticsearch_dsl==6.3.1

--- a/tests/test_esManager.py
+++ b/tests/test_esManager.py
@@ -134,7 +134,8 @@ class TestESManager(unittest.TestCase):
         testLink = TestDict(**{
             'url': 'test/url',
             'media_type': 'test',
-            'flags': '{\"local\": false}'
+            'flags': '{\"local\": false}',
+            'id': 1
         })
 
         linkRec = ESDoc.addLink(testLink)


### PR DESCRIPTION
This is a minor update to ensure that all `Link`s in the ElasticSearch index have a `unique_id` that can be used as a `key` in React. 

This is being implemented because the generated labels cannot be guaranteed to be unique, and while URLs should be, that cannot entirely be trusted either.

This repurposes the internal PostgreSQL row IDs for this purpose. This ensures that all links have a guaranteed unique identifier, which prevents errors and messages from appearing in the React console.