### PR TITLE
HOTFIX Change lambda size and index period

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,8 @@ aws_access_key_id:
 aws_secret_access_key:
 
 # dist_directory: dist
-timeout: 30
-memory_size: 128
+timeout: 900
+memory_size: 3008
 
 subnet_ids: ['subnet-12aa8a65', 'subnet-cd4a25e6']
 security_group_ids: ['sg-5521ef32']

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -15,4 +15,4 @@ environment_variables:
     ES_TIMEOUT: '10'
     ES_INDEX: sfr_test
 
-    INDEX_PERIOD: '7200'
+    INDEX_PERIOD: '1200'


### PR DESCRIPTION
A few general configuration updates to be sure that the elasticsearch manager runs in a logical way. First, the function has been sized up to 3008 MB to allow for faster runs. Second, the index period has been reduced to 1200 seconds, which actually reflects the index period.